### PR TITLE
Change the tekton target URL to an event listener one

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: cdf-events-keptn-adapter
-          image: salaboy/cdf-events-keptn-adapter:latest # Todo: Replace this with your image name
+          image: localhost:5000/cdevents/cdf-events-keptn-adapter:latest
           ports:
             - containerPort: 8080
           env:

--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -49,11 +49,15 @@ func HandleDeploymentTriggeredEvent(myKeptn *keptnv2.Keptn, incomingEvent cloude
 	values := data.ConfigurationChange.Values
 	if values["image"] != nil {
 		cdeData["image"] = values["image"].(string)
+		configurationChange := data.ConfigurationChange.Values
 		params := cde.ArtifactEventParams{
 			ArtifactId:      "",
 			ArtifactName:    data.Service,
 			ArtifactVersion: "",
 			ArtifactData:    cdeData,
+		}
+		if artifactId, ok := configurationChange["image"]; ok {
+			params.ArtifactId = artifactId.(string)
 		}
 
 		c, err := cloudevents.NewDefaultClient()

--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -68,7 +68,7 @@ func HandleDeploymentTriggeredEvent(myKeptn *keptnv2.Keptn, incomingEvent cloude
 		publishedArtifactEvent.SetSource("keptn-cd-translator-service")
 
 		// Set a target.
-		ctx := cloudevents.ContextWithTarget(context.Background(), "http://tekton-controller")
+		ctx := cloudevents.ContextWithTarget(context.Background(), "http://el-cdevent-listener.cdevents:8080")
 
 		// Send that Event.
 		log.Printf("sending event %s\n", publishedArtifactEvent)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/salaboy/cdf-events-keptn-adapter
 go 1.16
 
 require (
-	github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210616124232-6d6ea603dad5
+	github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210621161008-013ac0c4d953
 	github.com/cloudevents/sdk-go/v2 v2.3.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/keptn/go-utils v0.8.4

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210616124232-6d6ea603dad5 h1:S6xY+fPVldKDy7qcxFPqegdaPOoM579S2Wvvw7pmE7Y=
 github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210616124232-6d6ea603dad5/go.mod h1:xghRV+aIAccdyXaxtjeIxY/JhE8jrnEzBI6Ut+ZVS2Y=
+github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210621161008-013ac0c4d953 h1:wp4ESadQPWBzHh3zjvI88+M+CIkd+bx06EcCcioA+gU=
+github.com/cdfoundation/sig-events/cde/sdk/go v0.0.0-20210621161008-013ac0c4d953/go.mod h1:xghRV+aIAccdyXaxtjeIxY/JhE8jrnEzBI6Ut+ZVS2Y=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudevents/sdk-go/v2 v2.3.1 h1:QRTu0yRA4FbznjRSds0/4Hy6cVYpWV2wInlNJSHWAtw=


### PR DESCRIPTION
The URL is hardcoded for now. Set it to the one used in the PoC.
Change the image name to one in the local registry to work with
the PoC, so that the image can be easily updated by everyone
running the PoC.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>