### PR TITLE
Only send one event to the broken

### DIFF
--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -73,18 +73,12 @@ func HandleDeploymentTriggeredEvent(myKeptn *keptnv2.Keptn, incomingEvent cloude
 		publishedArtifactEvent, _ := cde.CreateArtifactEvent(cde.ArtifactPublishedEventV1, params)
 		publishedArtifactEvent.SetSource("keptn-cd-translator-service")
 
-		// Send that Event to Tekton.
-		ctxTekton := cloudevents.ContextWithTarget(context.Background(), "http://el-cdevent-listener.cdevents:8080")
+		// Send that Event to the event broken
+		brokerSink := "http://broker-ingress.knative-eventing.svc.cluster.local/default/events-broker"
+		ctx := cloudevents.ContextWithTarget(context.Background(), brokerSink)
 		log.Printf("sending event %s to Tekton\n", publishedArtifactEvent)
-		if result := c.Send(ctxTekton, publishedArtifactEvent); !cloudevents.IsACK(result) {
+		if result := c.Send(ctx, publishedArtifactEvent); !cloudevents.IsACK(result) {
 			log.Printf("failed to send to Tekton, %v", result)
-			return result
-		}
-		// Send that Event to Tekton.
-		ctxKeptn := cloudevents.ContextWithTarget(context.Background(), "http://keptn-cdevents.keptn:8080/events")
-		log.Printf("sending event %s to Keptn\n", publishedArtifactEvent)
-		if result := c.Send(ctxKeptn, publishedArtifactEvent); !cloudevents.IsACK(result) {
-			log.Printf("failed to send to Keptn, %v", result)
 			return result
 		}
 	}else{


### PR DESCRIPTION
Now that we use an event broker, send the event to the broker instead
of sending it to each individual client.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>